### PR TITLE
final_pc check

### DIFF
--- a/crates/air/src/layout/dex/mod.rs
+++ b/crates/air/src/layout/dex/mod.rs
@@ -360,7 +360,6 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?
@@ -392,7 +391,6 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/dex/mod.rs
+++ b/crates/air/src/layout/dex/mod.rs
@@ -395,7 +395,7 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
+        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/dex/mod.rs
+++ b/crates/air/src/layout/dex/mod.rs
@@ -360,10 +360,7 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-        let final_pc = public_segments
-            .get(segments::PROGRAM)
-            .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
-            .stop_ptr;
+
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?

--- a/crates/air/src/layout/dynamic/mod.rs
+++ b/crates/air/src/layout/dynamic/mod.rs
@@ -768,7 +768,7 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
+        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/dynamic/mod.rs
+++ b/crates/air/src/layout/dynamic/mod.rs
@@ -733,10 +733,7 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-        let final_pc = public_segments
-            .get(segments::PROGRAM)
-            .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
-            .stop_ptr;
+
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?

--- a/crates/air/src/layout/dynamic/mod.rs
+++ b/crates/air/src/layout/dynamic/mod.rs
@@ -733,7 +733,6 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?
@@ -765,7 +764,6 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/recursive/mod.rs
+++ b/crates/air/src/layout/recursive/mod.rs
@@ -360,7 +360,6 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?
@@ -392,7 +391,6 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/recursive/mod.rs
+++ b/crates/air/src/layout/recursive/mod.rs
@@ -395,7 +395,7 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
+        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/recursive/mod.rs
+++ b/crates/air/src/layout/recursive/mod.rs
@@ -360,10 +360,7 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-        let final_pc = public_segments
-            .get(segments::PROGRAM)
-            .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
-            .stop_ptr;
+
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?

--- a/crates/air/src/layout/recursive_with_poseidon/mod.rs
+++ b/crates/air/src/layout/recursive_with_poseidon/mod.rs
@@ -417,7 +417,6 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?
@@ -449,7 +448,6 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/recursive_with_poseidon/mod.rs
+++ b/crates/air/src/layout/recursive_with_poseidon/mod.rs
@@ -452,7 +452,7 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
+        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/recursive_with_poseidon/mod.rs
+++ b/crates/air/src/layout/recursive_with_poseidon/mod.rs
@@ -417,10 +417,7 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-        let final_pc = public_segments
-            .get(segments::PROGRAM)
-            .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
-            .stop_ptr;
+
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?

--- a/crates/air/src/layout/small/mod.rs
+++ b/crates/air/src/layout/small/mod.rs
@@ -360,7 +360,6 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?
@@ -392,7 +391,6 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/small/mod.rs
+++ b/crates/air/src/layout/small/mod.rs
@@ -395,7 +395,7 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
+        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/small/mod.rs
+++ b/crates/air/src/layout/small/mod.rs
@@ -360,10 +360,7 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-        let final_pc = public_segments
-            .get(segments::PROGRAM)
-            .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
-            .stop_ptr;
+
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?

--- a/crates/air/src/layout/starknet/mod.rs
+++ b/crates/air/src/layout/starknet/mod.rs
@@ -487,10 +487,7 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-        let final_pc = public_segments
-            .get(segments::PROGRAM)
-            .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
-            .stop_ptr;
+
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?

--- a/crates/air/src/layout/starknet/mod.rs
+++ b/crates/air/src/layout/starknet/mod.rs
@@ -487,7 +487,6 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?
@@ -519,7 +518,6 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/starknet/mod.rs
+++ b/crates/air/src/layout/starknet/mod.rs
@@ -522,7 +522,7 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
+        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/starknet_with_keccak/mod.rs
+++ b/crates/air/src/layout/starknet_with_keccak/mod.rs
@@ -536,10 +536,7 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-        let final_pc = public_segments
-            .get(segments::PROGRAM)
-            .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
-            .stop_ptr;
+
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?

--- a/crates/air/src/layout/starknet_with_keccak/mod.rs
+++ b/crates/air/src/layout/starknet_with_keccak/mod.rs
@@ -571,7 +571,7 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
+        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 

--- a/crates/air/src/layout/starknet_with_keccak/mod.rs
+++ b/crates/air/src/layout/starknet_with_keccak/mod.rs
@@ -536,7 +536,6 @@ impl LayoutTrait for Layout {
             .get(segments::PROGRAM)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::PROGRAM })?
             .begin_addr;
-
         let initial_ap = public_segments
             .get(segments::EXECUTION)
             .ok_or(PublicInputError::SegmentMissing { segment: segments::EXECUTION })?
@@ -568,7 +567,6 @@ impl LayoutTrait for Layout {
             .collect::<Vec<Felt>>();
 
         ensure!(initial_pc == INITIAL_PC, PublicInputError::MaxSteps);
-        // ensure!(final_pc == INITIAL_PC + FELT_4, PublicInputError::MaxSteps);
 
         let program_end_pc = initial_fp - FELT_2;
 


### PR DESCRIPTION
This PR removes final_pc check from public memory validation
The check verified `initial_pc + 4 = final_pc` and it is satisfied when `python-vm` is used
When the program is ran in `cairo-vm` the memory layout is different and the check is no longer satisfied
This change is not modifying STARK verifying logic