### PR TITLE
feat: make `parse()` accept `&str`

### DIFF
--- a/proof_parser/src/lib.rs
+++ b/proof_parser/src/lib.rs
@@ -6,8 +6,8 @@ pub mod stark_proof;
 
 pub use stark_proof::*;
 
-pub fn parse(input: String) -> anyhow::Result<stark_proof::StarkProof> {
-    let proof_json = serde_json::from_str::<json_parser::StarkProof>(&input)?;
+pub fn parse<I: AsRef<str>>(input: I) -> anyhow::Result<stark_proof::StarkProof> {
+    let proof_json = serde_json::from_str::<json_parser::StarkProof>(input.as_ref())?;
     stark_proof::StarkProof::try_from(proof_json)
 }
 


### PR DESCRIPTION
There's no reason the `parse()` function would take a owned `String` while all it really needs is a referenced `str`. This function is re-exported so it makes sense to make it as generic as possible. The current implementation forces downstream applications to unnecessarily clone source strings.

This PR fixes it by making the parameter generic without breaking public API. `String` is still accepted.