### PR TITLE
feat: derive `Clone` for `StarkProof`

### DIFF
--- a/crates/air/src/public_memory.rs
+++ b/crates/air/src/public_memory.rs
@@ -16,7 +16,7 @@ pub const MAX_ADDRESS: Felt = Felt::from_hex_unchecked("0xffffffffffffffff");
 pub const INITIAL_PC: Felt = Felt::from_hex_unchecked("0x1");
 
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PublicInput {
     #[cfg_attr(
         feature = "std",

--- a/crates/air/src/trace/mod.rs
+++ b/crates/air/src/trace/mod.rs
@@ -8,7 +8,7 @@ use starknet_crypto::Felt;
 // Commitment values for the Traces component. Used to generate a commitment by "reading" these
 // values from the channel.
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UnsentCommitment {
     #[cfg_attr(
         feature = "std",

--- a/crates/air/src/types.rs
+++ b/crates/air/src/types.rs
@@ -5,7 +5,7 @@ use serde_with::serde_as;
 use starknet_crypto::Felt;
 
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SegmentInfo {
     // Start address of the memory segment.
     #[cfg_attr(
@@ -22,7 +22,7 @@ pub struct SegmentInfo {
 }
 
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AddrValue {
     #[cfg_attr(
         feature = "std",
@@ -36,7 +36,7 @@ pub struct AddrValue {
     pub value: Felt,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Page(pub Vec<AddrValue>);
 
 impl Deref for Page {
@@ -73,7 +73,7 @@ impl Page {
 //   z     = interaction_elements.memory_multi_column_perm_perm__interaction_elm
 //   alpha = interaction_elements.memory_multi_column_perm_hash_interaction_elm0
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContinuousPageHeader {
     // Start address.
     #[cfg_attr(

--- a/crates/pow/src/config.rs
+++ b/crates/pow/src/config.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 const MAX_PROOF_OF_WORK_BITS: u8 = 50;
 const MIN_PROOF_OF_WORK_BITS: u8 = 20;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     // Proof of work difficulty (number of bits required to be 0).
     pub n_bits: u8,

--- a/crates/pow/src/pow.rs
+++ b/crates/pow/src/pow.rs
@@ -16,7 +16,7 @@ use crate::config::Config;
 
 const MAGIC: u64 = 0x0123456789abcded;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UnsentCommitment {
     pub nonce: u64,
 }

--- a/crates/stark/src/config.rs
+++ b/crates/stark/src/config.rs
@@ -4,7 +4,7 @@ use starknet_crypto::Felt;
 use swiftness_commitment::vector;
 
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StarkConfig {
     pub traces: swiftness_air::trace::config::Config,
     pub composition: swiftness_commitment::table::config::Config,

--- a/crates/stark/src/types.rs
+++ b/crates/stark/src/types.rs
@@ -5,7 +5,7 @@ use starknet_crypto::Felt;
 
 use crate::config;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StarkProof {
     pub config: config::StarkConfig,
     pub public_input: swiftness_air::public_memory::PublicInput,
@@ -14,7 +14,7 @@ pub struct StarkProof {
 }
 
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StarkUnsentCommitment {
     pub traces: swiftness_air::trace::UnsentCommitment,
     #[cfg_attr(
@@ -57,7 +57,7 @@ pub struct StarkCommitment<InteractionElements> {
     pub fri: swiftness_fri::types::Commitment,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StarkWitness {
     pub traces_decommitment: swiftness_air::trace::Decommitment,
     pub traces_witness: swiftness_air::trace::Witness,


### PR DESCRIPTION
Another minor quality of life improvement to make `StarkProof` cloneable.